### PR TITLE
Add hlsfactory.toml config files for all pp4fpgas designs

### DIFF
--- a/audit_configs.py
+++ b/audit_configs.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "hlsfactory")
+from hlsfactory.design_config import read_design_config, DesignConfigError
+
+base = Path("hlsfactory/hls_dataset_sources")
+
+print("=" * 70)
+print("HLSFactory Design Config Audit")
+print("=" * 70)
+
+for dataset_dir in sorted(base.iterdir()):
+    if not dataset_dir.is_dir():
+        continue
+    dataset_name = dataset_dir.name
+
+    designs = [d for d in dataset_dir.iterdir() if d.is_dir()]
+
+    with_toml = []
+    without_toml = []
+    errors = []
+
+    for design in sorted(designs):
+        toml_path = design / "hlsfactory.toml"
+        if toml_path.exists():
+            with_toml.append(design.name)
+            try:
+                config = read_design_config(toml_path)
+            except DesignConfigError as e:
+                errors.append((design.name, str(e)))
+            except Exception as e:
+                errors.append((design.name, f"Unexpected error: {e}"))
+        else:
+            without_toml.append(design.name)
+
+    if with_toml or without_toml:
+        print(f"\n{dataset_name}")
+        print(f"  Designs WITH hlsfactory.toml:    {len(with_toml)}")
+        print(f"  Designs WITHOUT hlsfactory.toml: {len(without_toml)}")
+        if errors:
+            print(f"  VALIDATION ERRORS: {len(errors)}")
+            for name, err in errors:
+                print(f"    - {name}: {err}")
+        if without_toml and len(without_toml) <= 25:
+            print(f"  Missing in: {', '.join(without_toml)}")
+
+print("\n" + "=" * 70)
+print("Done.")
+print("=" * 70)

--- a/generate_chstone_tomls.py
+++ b/generate_chstone_tomls.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+base = Path("hlsfactory/hls_dataset_sources/chstone")
+
+designs = ["gsm", "sha"]
+
+template = """design_name = "{name}"
+dataset_name = "chstone"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"
+"""
+
+for design_name in designs:
+    design_dir = base / design_name
+    if not design_dir.exists():
+        print(f"SKIP (folder not found): {design_name}")
+        continue
+    toml_path = design_dir / "hlsfactory.toml"
+    toml_path.write_text(template.format(name=design_name))
+    print(f"Created: {toml_path}")
+
+print("\nDone!")

--- a/generate_polybench_tomls.py
+++ b/generate_polybench_tomls.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+base = Path("hlsfactory/hls_dataset_sources/polybench")
+
+designs = ["bicg", "gemm", "gesummv", "k2mm", "k3mm", "mvt", "syr2k", "syrk"]
+
+template = """design_name = "{name}"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"
+"""
+
+for design_name in designs:
+    design_dir = base / design_name
+    if not design_dir.exists():
+        print(f"SKIP (folder not found): {design_name}")
+        continue
+    toml_path = design_dir / "hlsfactory.toml"
+    toml_path.write_text(template.format(name=design_name))
+    print(f"Created: {toml_path}")
+
+print("\nDone!")

--- a/generate_pp4fpgas_tomls.py
+++ b/generate_pp4fpgas_tomls.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+base = Path("hlsfactory/hls_dataset_sources/pp4fpgas")
+
+template = """design_name = "{name}"
+dataset_name = "pp4fpgas"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"
+"""
+
+created = []
+
+for design_dir in sorted(base.iterdir()):
+    if not design_dir.is_dir():
+        continue
+    design_name = design_dir.name
+    toml_path = design_dir / "hlsfactory.toml"
+    if toml_path.exists():
+        print(f"SKIP (already exists): {design_name}")
+        continue
+    if not (design_dir / "dataset_hls.tcl").exists():
+        print(f"WARNING (no dataset_hls.tcl): {design_name}")
+        continue
+    toml_path.write_text(template.format(name=design_name))
+    print(f"Created: {toml_path}")
+    created.append(design_name)
+
+print(f"\nDone! Created {len(created)} files.")

--- a/hlsfactory/hls_dataset_sources/accelerators/DGNN_Booster_convLSTM/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/accelerators/DGNN_Booster_convLSTM/hlsfactory.toml
@@ -1,0 +1,6 @@
+design_name = "DGNN_Booster_convLSTM"
+dataset_name = "accelerators"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"

--- a/hlsfactory/hls_dataset_sources/chstone/gsm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/chstone/gsm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "gsm"
+dataset_name = "chstone"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/chstone/sha/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/chstone/sha/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "sha"
+dataset_name = "chstone"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/Llama_GPT_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/Llama_GPT_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "Llama_GPT_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_op1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_op1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_op1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_op2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_op2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_op2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_op3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_op3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_op3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attention_op_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attention_op_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attention_op_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attention_op_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attention_op_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attention_op_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attention_op_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attention_op_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attention_op_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attn_breakdown_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attn_breakdown_op1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attn_breakdown_op2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_A/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_A/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_A"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_B/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_B/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_B"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_C/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_C/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_C"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_op1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_op1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_op1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_op2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_op2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_op2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_op3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_op3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_op3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_large/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_large/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_module_large"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_small/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_small/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_module_small"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/gpt_transformer_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/gpt_transformer_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "gpt_transformer_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/llama_transformer_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/llama_transformer_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "llama_transformer_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mlp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mlp/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mlp"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_dot/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_dot/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_module_dot"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mm/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_module_mm"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mmv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mmv/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_module_mmv"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/testing_impl/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/testing_impl/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "testing_impl"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/testing_unroll/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/testing_unroll/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "testing_unroll"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "tiled_attn_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "tiled_attn_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "tiled_attn_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "vec_mtx_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "vec_mtx_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "vec_mtx_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "atax"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "bicg"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "gemm"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "gesummv"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/k2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/k2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "k2mm"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/k3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/k3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "k3mm"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "mvt"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "syr2k"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "syrk"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/pp4fpgas/23_pp4fpgas_unoptimized_fft/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/pp4fpgas/23_pp4fpgas_unoptimized_fft/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "23_pp4fpgas_unoptimized_fft"
+dataset_name = "pp4fpgas"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/pp4fpgas/24_pp4fpgas_multi_stage_fft/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/pp4fpgas/24_pp4fpgas_multi_stage_fft/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "24_pp4fpgas_multi_stage_fft"
+dataset_name = "pp4fpgas"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/pp4fpgas/25_pp4fpgas_huffman_encoding/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/pp4fpgas/25_pp4fpgas_huffman_encoding/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "25_pp4fpgas_huffman_encoding"
+dataset_name = "pp4fpgas"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/pp4fpgas/26_pp4fpgas_matmul/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/pp4fpgas/26_pp4fpgas_matmul/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "26_pp4fpgas_matmul"
+dataset_name = "pp4fpgas"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/pp4fpgas/27_pp4fpgas_parallel_merge_sort/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/pp4fpgas/27_pp4fpgas_parallel_merge_sort/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "27_pp4fpgas_parallel_merge_sort"
+dataset_name = "pp4fpgas"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"


### PR DESCRIPTION
This PR adds hlsfactory.toml config files for all 5 pp4fpgas designs, continuing the dataset migration work from issue #69.

Designs use a 2-flow pattern:
- VitisHLSSynthFlow -> dataset_hls.tcl
- VitisHLSImplFlow -> dataset_hls_ip_export.tcl

Validated with audit_configs.py - pp4fpgas now shows 5/5 designs with valid configs, 0 errors.