### PR TITLE
Add hlsfactory.toml config files for all polybench__reproducible designs (196 designs)

### DIFF
--- a/audit_configs.py
+++ b/audit_configs.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "hlsfactory")
+from hlsfactory.design_config import read_design_config, DesignConfigError
+
+base = Path("hlsfactory/hls_dataset_sources")
+
+print("=" * 70)
+print("HLSFactory Design Config Audit")
+print("=" * 70)
+
+for dataset_dir in sorted(base.iterdir()):
+    if not dataset_dir.is_dir():
+        continue
+    dataset_name = dataset_dir.name
+
+    designs = [d for d in dataset_dir.iterdir() if d.is_dir()]
+
+    with_toml = []
+    without_toml = []
+    errors = []
+
+    for design in sorted(designs):
+        toml_path = design / "hlsfactory.toml"
+        if toml_path.exists():
+            with_toml.append(design.name)
+            try:
+                config = read_design_config(toml_path)
+            except DesignConfigError as e:
+                errors.append((design.name, str(e)))
+            except Exception as e:
+                errors.append((design.name, f"Unexpected error: {e}"))
+        else:
+            without_toml.append(design.name)
+
+    if with_toml or without_toml:
+        print(f"\n{dataset_name}")
+        print(f"  Designs WITH hlsfactory.toml:    {len(with_toml)}")
+        print(f"  Designs WITHOUT hlsfactory.toml: {len(without_toml)}")
+        if errors:
+            print(f"  VALIDATION ERRORS: {len(errors)}")
+            for name, err in errors:
+                print(f"    - {name}: {err}")
+        if without_toml and len(without_toml) <= 25:
+            print(f"  Missing in: {', '.join(without_toml)}")
+
+print("\n" + "=" * 70)
+print("Done.")
+print("=" * 70)

--- a/generate_chstone_tomls.py
+++ b/generate_chstone_tomls.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+base = Path("hlsfactory/hls_dataset_sources/chstone")
+
+designs = ["gsm", "sha"]
+
+template = """design_name = "{name}"
+dataset_name = "chstone"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"
+"""
+
+for design_name in designs:
+    design_dir = base / design_name
+    if not design_dir.exists():
+        print(f"SKIP (folder not found): {design_name}")
+        continue
+    toml_path = design_dir / "hlsfactory.toml"
+    toml_path.write_text(template.format(name=design_name))
+    print(f"Created: {toml_path}")
+
+print("\nDone!")

--- a/generate_polybench_reproducible_tomls.py
+++ b/generate_polybench_reproducible_tomls.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+base = Path("hlsfactory/hls_dataset_sources/polybench__reproducible")
+
+template = """design_name = "{group}__{name}"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"
+"""
+
+created = []
+
+for group_dir in sorted(base.iterdir()):
+    if not group_dir.is_dir():
+        continue
+    group_name = group_dir.name
+    for design_dir in sorted(group_dir.iterdir()):
+        if not design_dir.is_dir():
+            continue
+        design_name = design_dir.name
+        toml_path = design_dir / "hlsfactory.toml"
+        if toml_path.exists():
+            print(f"SKIP (already exists): {group_name}/{design_name}")
+            continue
+        if not (design_dir / "dataset_hls.tcl").exists():
+            print(f"WARNING (no dataset_hls.tcl): {group_name}/{design_name}")
+            continue
+        toml_path.write_text(template.format(group=group_name, name=design_name))
+        print(f"Created: {toml_path}")
+        created.append(design_name)
+
+print(f"\nDone! Created {len(created)} files.")

--- a/generate_polybench_tomls.py
+++ b/generate_polybench_tomls.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+base = Path("hlsfactory/hls_dataset_sources/polybench")
+
+designs = ["bicg", "gemm", "gesummv", "k2mm", "k3mm", "mvt", "syr2k", "syrk"]
+
+template = """design_name = "{name}"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"
+"""
+
+for design_name in designs:
+    design_dir = base / design_name
+    if not design_dir.exists():
+        print(f"SKIP (folder not found): {design_name}")
+        continue
+    toml_path = design_dir / "hlsfactory.toml"
+    toml_path.write_text(template.format(name=design_name))
+    print(f"Created: {toml_path}")
+
+print("\nDone!")

--- a/hlsfactory/hls_dataset_sources/accelerators/DGNN_Booster_convLSTM/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/accelerators/DGNN_Booster_convLSTM/hlsfactory.toml
@@ -1,0 +1,6 @@
+design_name = "DGNN_Booster_convLSTM"
+dataset_name = "accelerators"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"

--- a/hlsfactory/hls_dataset_sources/chstone/gsm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/chstone/gsm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "gsm"
+dataset_name = "chstone"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/chstone/sha/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/chstone/sha/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "sha"
+dataset_name = "chstone"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/Llama_GPT_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/Llama_GPT_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "Llama_GPT_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_op1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_op1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_op1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_op2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_op2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_op2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/activation_op3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/activation_op3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "activation_op3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attention_op_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attention_op_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attention_op_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attention_op_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attention_op_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attention_op_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attention_op_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attention_op_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attention_op_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attn_breakdown_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attn_breakdown_op1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/attn_breakdown_op2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "attn_breakdown_op2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_A/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_A/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_A"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_B/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_B/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_B"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_C/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_C/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_C"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_op1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_op1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_op1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_op2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_op2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_op2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_block_op3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_block_op3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_block_op3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/conv_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/conv_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "conv_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_large/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_large/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_module_large"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_small/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_module_small/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_module_small"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_dims_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_dims_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/diff_orders_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "diff_orders_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/gpt_transformer_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/gpt_transformer_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "gpt_transformer_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/llama_transformer_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/llama_transformer_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "llama_transformer_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mlp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mlp/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mlp"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_dot/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_dot/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_module_dot"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mm/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_module_mm"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mmv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_module_mmv/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_module_mmv"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/mult_op_p3/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/mult_op_p3/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "mult_op_p3"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/testing_impl/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/testing_impl/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "testing_impl"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/testing_unroll/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/testing_unroll/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "testing_unroll"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "tiled_attn_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "tiled_attn_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/tiled_attn_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "tiled_attn_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_module/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_module/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "vec_mtx_module"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p1/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p1/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "vec_mtx_p1"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p2/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/forgebench/vec_mtx_p2/hlsfactory.toml
@@ -1,0 +1,10 @@
+design_name = "vec_mtx_p2"
+dataset_name = "forgebench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "atax"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "bicg"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "gemm"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "gesummv"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/k2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/k2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "k2mm"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/k3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/k3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "k3mm"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "mvt"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "syr2k"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "syrk"
+dataset_name = "polybench"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__2mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__3mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__atax"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__bicg"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/cholesky/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/cholesky/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__cholesky"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/correlation/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/correlation/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__correlation"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/covariance/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/covariance/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__covariance"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/doitgen/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/doitgen/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__doitgen"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/durbin/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/durbin/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__durbin"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/fdtd-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/fdtd-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__fdtd-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/floyd-warshall/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/floyd-warshall/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__floyd-warshall"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__gemm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gemver/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gemver/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__gemver"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__gesummv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gramschmidt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/gramschmidt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__gramschmidt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/heat-3d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/heat-3d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__heat-3d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/jacobi-1d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/jacobi-1d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__jacobi-1d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/jacobi-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/jacobi-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__jacobi-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/lu/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/lu/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__lu"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/ludcmp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/ludcmp/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__ludcmp"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__mvt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/nussinov/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/nussinov/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__nussinov"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/seidel-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/seidel-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__seidel-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/symm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/symm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__symm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__syr2k"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__syrk"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/trisolv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/trisolv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__trisolv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/trmm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__medium/trmm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__medium__trmm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__2mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__3mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__atax"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__bicg"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/cholesky/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/cholesky/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__cholesky"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/correlation/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/correlation/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__correlation"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/covariance/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/covariance/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__covariance"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/doitgen/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/doitgen/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__doitgen"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/durbin/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/durbin/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__durbin"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/fdtd-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/fdtd-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__fdtd-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/floyd-warshall/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/floyd-warshall/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__floyd-warshall"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__gemm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gemver/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gemver/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__gemver"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__gesummv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gramschmidt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/gramschmidt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__gramschmidt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/heat-3d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/heat-3d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__heat-3d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/jacobi-1d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/jacobi-1d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__jacobi-1d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/jacobi-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/jacobi-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__jacobi-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/lu/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/lu/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__lu"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/ludcmp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/ludcmp/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__ludcmp"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__mvt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/nussinov/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/nussinov/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__nussinov"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/seidel-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/seidel-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__seidel-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/symm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/symm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__symm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__syr2k"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__syrk"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/trisolv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/trisolv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__trisolv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/trmm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__mini/trmm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__mini__trmm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__2mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__3mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__atax"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__bicg"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/cholesky/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/cholesky/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__cholesky"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/correlation/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/correlation/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__correlation"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/covariance/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/covariance/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__covariance"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/doitgen/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/doitgen/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__doitgen"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/durbin/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/durbin/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__durbin"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/fdtd-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/fdtd-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__fdtd-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/floyd-warshall/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/floyd-warshall/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__floyd-warshall"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__gemm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gemver/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gemver/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__gemver"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__gesummv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gramschmidt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/gramschmidt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__gramschmidt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/heat-3d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/heat-3d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__heat-3d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/jacobi-1d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/jacobi-1d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__jacobi-1d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/jacobi-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/jacobi-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__jacobi-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/lu/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/lu/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__lu"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/ludcmp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/ludcmp/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__ludcmp"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__mvt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/nussinov/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/nussinov/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__nussinov"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/seidel-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/seidel-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__seidel-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/symm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/symm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__symm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__syr2k"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__syrk"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/trisolv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/trisolv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__trisolv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/trmm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__fixed__small/trmm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__fixed__small__trmm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__2mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__3mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__atax"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__bicg"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/cholesky/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/cholesky/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__cholesky"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/correlation/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/correlation/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__correlation"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/covariance/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/covariance/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__covariance"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/doitgen/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/doitgen/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__doitgen"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/durbin/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/durbin/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__durbin"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/fdtd-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/fdtd-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__fdtd-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/floyd-warshall/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/floyd-warshall/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__floyd-warshall"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__gemm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gemver/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gemver/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__gemver"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__gesummv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gramschmidt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/gramschmidt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__gramschmidt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/heat-3d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/heat-3d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__heat-3d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/jacobi-1d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/jacobi-1d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__jacobi-1d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/jacobi-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/jacobi-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__jacobi-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/lu/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/lu/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__lu"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/ludcmp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/ludcmp/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__ludcmp"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__mvt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/nussinov/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/nussinov/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__nussinov"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/seidel-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/seidel-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__seidel-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/symm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/symm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__symm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__syr2k"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__syrk"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/trisolv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/trisolv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__trisolv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/trmm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__medium/trmm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__medium__trmm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__2mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__3mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__atax"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__bicg"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/cholesky/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/cholesky/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__cholesky"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/correlation/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/correlation/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__correlation"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/covariance/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/covariance/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__covariance"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/doitgen/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/doitgen/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__doitgen"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/durbin/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/durbin/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__durbin"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/fdtd-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/fdtd-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__fdtd-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/floyd-warshall/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/floyd-warshall/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__floyd-warshall"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__gemm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gemver/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gemver/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__gemver"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__gesummv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gramschmidt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/gramschmidt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__gramschmidt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/heat-3d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/heat-3d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__heat-3d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/jacobi-1d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/jacobi-1d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__jacobi-1d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/jacobi-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/jacobi-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__jacobi-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/lu/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/lu/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__lu"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/ludcmp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/ludcmp/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__ludcmp"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__mvt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/nussinov/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/nussinov/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__nussinov"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/seidel-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/seidel-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__seidel-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/symm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/symm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__symm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__syr2k"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__syrk"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/trisolv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/trisolv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__trisolv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/trmm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__mini/trmm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__mini__trmm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__2mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__3mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__atax"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__bicg"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/cholesky/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/cholesky/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__cholesky"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/correlation/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/correlation/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__correlation"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/covariance/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/covariance/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__covariance"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/doitgen/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/doitgen/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__doitgen"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/durbin/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/durbin/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__durbin"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/fdtd-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/fdtd-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__fdtd-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/floyd-warshall/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/floyd-warshall/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__floyd-warshall"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__gemm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gemver/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gemver/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__gemver"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__gesummv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gramschmidt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/gramschmidt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__gramschmidt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/heat-3d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/heat-3d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__heat-3d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/jacobi-1d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/jacobi-1d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__jacobi-1d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/jacobi-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/jacobi-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__jacobi-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/lu/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/lu/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__lu"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/ludcmp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/ludcmp/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__ludcmp"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__mvt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/nussinov/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/nussinov/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__nussinov"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/seidel-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/seidel-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__seidel-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/symm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/symm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__symm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__syr2k"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__syrk"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/trisolv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/trisolv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__trisolv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/trmm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__small/trmm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__small__trmm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/2mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/2mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__2mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/3mm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/3mm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__3mm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/atax/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/atax/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__atax"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/bicg/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/bicg/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__bicg"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/cholesky/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/cholesky/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__cholesky"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/correlation/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/correlation/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__correlation"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/covariance/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/covariance/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__covariance"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/doitgen/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/doitgen/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__doitgen"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/durbin/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/durbin/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__durbin"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/fdtd-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/fdtd-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__fdtd-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/floyd-warshall/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/floyd-warshall/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__floyd-warshall"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gemm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gemm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__gemm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gemver/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gemver/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__gemver"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gesummv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gesummv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__gesummv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gramschmidt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/gramschmidt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__gramschmidt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/heat-3d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/heat-3d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__heat-3d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/jacobi-1d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/jacobi-1d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__jacobi-1d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/jacobi-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/jacobi-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__jacobi-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/lu/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/lu/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__lu"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/ludcmp/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/ludcmp/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__ludcmp"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/mvt/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/mvt/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__mvt"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/nussinov/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/nussinov/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__nussinov"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/seidel-2d/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/seidel-2d/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__seidel-2d"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/symm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/symm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__symm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/syr2k/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/syr2k/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__syr2k"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/syrk/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/syrk/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__syrk"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/trisolv/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/trisolv/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__trisolv"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"

--- a/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/trmm/hlsfactory.toml
+++ b/hlsfactory/hls_dataset_sources/polybench__reproducible/polybench__float__unsafe__math__mini/trmm/hlsfactory.toml
@@ -1,0 +1,14 @@
+design_name = "polybench__float__unsafe__math__mini__trmm"
+dataset_name = "polybench__reproducible"
+
+[[flow_configs]]
+flow_name = "VitisHLSSynthFlow"
+synth_tcl = "dataset_hls.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSCosimSetupFlow"
+cosim_setup_tcl = "dataset_hls_cosim_setup.tcl"
+
+[[flow_configs]]
+flow_name = "VitisHLSImplFlow"
+impl_tcl = "dataset_hls_ip_export.tcl"


### PR DESCRIPTION
This PR adds hlsfactory.toml config files for all 196 polybench__reproducible designs, continuing the dataset migration work from issue #69.

The dataset has 7 groups (fixed/float x mini/small/medium, plus float unsafe math mini), each containing 28 kernel designs. All designs follow the same 3-flow pattern as the original polybench dataset:
- VitisHLSSynthFlow -> dataset_hls.tcl
- VitisHLSCosimSetupFlow -> dataset_hls_cosim_setup.tcl
- VitisHLSImplFlow -> dataset_hls_ip_export.tcl

Validated with audit_configs.py - all 196 designs show valid configs, 0 errors.