### PR TITLE
Adding OptDSLPassthroughFrontend to FLOW_NAME_MAP in dataset_validator.py

### DIFF
--- a/tests/dataset_validator.py
+++ b/tests/dataset_validator.py
@@ -10,6 +10,7 @@ from hlsfactory.flow_vitis import (
     VitisHLSImplFlow,
     VitisHLSSynthFlow,
 )
+from hlsfactory.opt_dsl_frontend import OptDSLPassthroughFrontend
 from hlsfactory.framework import (
     DesignDataset,
     Flow,
@@ -36,6 +37,7 @@ FLOW_NAME_MAP = {
     "VitisHLSCosimSetupFlow": VitisHLSCosimSetupFlow,
     "VitisHLSCosimFlow": VitisHLSCosimFlow,
     "VitisHLSCsimFlow": VitisHLSCsimFlow,
+    "OptDSLPassthroughFrontend": OptDSLPassthroughFrontend,
 }
 
 
@@ -111,6 +113,10 @@ def main(args) -> None:
             ):
                 flow_instance = cls(
                     vitis_hls_bin=str(BIN_VITIS_HLS),
+                )
+            case cls if cls is OptDSLPassthroughFrontend:
+                flow_instance = cls(
+                    work_dir=work_dir,
                 )
             case _:
                 raise NotImplementedError(f"Flow {flow!r} is not yet supported.")


### PR DESCRIPTION
Fixes the `ValueError: Flow OptDSLPassthroughFrontend not found in FLOW_NAME_MAP` error when running dataset_validator.py with `--flow OptDSLPassthroughFrontend+VitisHLSSynthFlow`, as suggested in issue #61 discussion for testing PolyBench/CHStone which need opt.tcl generated before synthesis.

Changes:
- Import OptDSLPassthroughFrontend from hlsfactory.opt_dsl_frontend
- Add it to FLOW_NAME_MAP
- Add a match case to instantiate it with the work_dir argument (since it takes a different constructor signature than the Vitis flow classes)

Tested on PolyBench (9/9 designs) and CHStone - both stages (OptDSLPassthroughFrontend + VitisHLSSynthFlow) complete successfully with real execution_time_data.json output for each design.