### PR TITLE
Add support for skipping already-completed flows (issue #73)

### DIFF
--- a/hlsfactory/flow_vitis.py
+++ b/hlsfactory/flow_vitis.py
@@ -12,6 +12,7 @@ from hlsfactory.utils import (
     CallToolResult,
     call_tool,
     find_bin_path,
+    flow_already_completed,
     log_execution_time_to_file,
     serialize_methods_for_dataclass,
     timeout_not_supported,
@@ -282,9 +283,17 @@ class VitisHLSSynthFlow(ToolFlow):
         self.env_var_xilinx_vivado = env_var_xilinx_vivado
 
     def execute(self, design: Design, timeout: float | None = None) -> list[Design]:
-        t_0 = time.perf_counter()
-
         design_dir = design.dir
+
+        if flow_already_completed(
+            design_dir,
+            self.name,
+            success_marker_fp=design_dir / "data_hls.json",
+        ):
+            print(f"[{design_dir}] Skipping {self.name}, already completed")
+            return [design]
+
+        t_0 = time.perf_counter()
 
         # Get TCL file path from design config
         config = design.require_config()

--- a/hlsfactory/utils.py
+++ b/hlsfactory/utils.py
@@ -172,6 +172,44 @@ def log_execution_time_to_file(
     execution_time_data_fp.write_text(json.dumps(execution_time_data, indent=4))
 
 
+def flow_already_completed(
+    design_dir: Path,
+    flow_name: str,
+    success_marker_fp: Path | None = None,
+) -> bool:
+    """
+    Checks whether a flow has already been completed successfully for a design.
+
+    Args:
+        design_dir (Path): The directory where the design is located.
+        flow_name (str): The name of the flow to check.
+        success_marker_fp (Path | None): An optional file path that must exist
+            for the flow to be considered successfully completed (e.g. a
+            report or output data file). If None, only the execution time
+            log and absence of error/timeout markers are checked.
+
+    Returns:
+        bool: True if the flow already completed successfully, False otherwise.
+    """
+    execution_time_data_fp = design_dir / "execution_time_data.json"
+    if not execution_time_data_fp.exists():
+        return False
+
+    execution_time_data = json.loads(execution_time_data_fp.read_text())
+    if flow_name not in execution_time_data:
+        return False
+
+    error_fp = design_dir / f"error__{flow_name}.txt"
+    timeout_fp = design_dir / f"timeout__{flow_name}.txt"
+    if error_fp.exists() or timeout_fp.exists():
+        return False
+
+    if success_marker_fp is not None and not success_marker_fp.exists():
+        return False
+
+    return True
+
+
 class FlowTimer:
     """
     A class for measuring the execution time of a flow.


### PR DESCRIPTION
Addresses #73 by adding a way to detect and skip flows that have already completed successfully, avoiding redundant re-synthesis on subsequent runs.

Changes:
- Added `flow_already_completed()` helper in `utils.py`. Checks whether:
  1. `execution_time_data.json` has an entry for the given flow name
  2. No `error__{flow_name}.txt` or `timeout__{flow_name}.txt` marker exists
  3. (Optionally) a success marker file exists (e.g. a report/output file)
- Wired this into `VitisHLSSynthFlow.execute()` as a proof of concept, using `data_hls.json` as the success marker. If the flow already completed, it prints a skip message and returns immediately instead of re-running Vitis HLS.

Tested directly on soda__blur:
- First run: 118.44 seconds (real synthesis)
- Second run: 0.00 seconds (skipped, printed "Skipping VitisHLSSynthFlow, already completed")

This is a minimal starting point — happy to extend the same pattern to VitisHLSImplFlow, VitisHLSCsimFlow, and the other flow classes if this approach looks right to you. Also open to feedback on whether the "design flow log" idea you described should be a more structured/centralized format rather than reusing execution_time_data.json.